### PR TITLE
处理compileshader因为context的pipelinemode导致shader编译跳过的问题

### DIFF
--- a/src/layaAir/laya/d3/RenderObjs/RenderObj/BaseRenderQueue.ts
+++ b/src/layaAir/laya/d3/RenderObjs/RenderObj/BaseRenderQueue.ts
@@ -78,7 +78,8 @@ export class BaseRenderQueue implements IRenderQueue {
 
         for (var i: number = 0, n = this.elements.length; i < n; i++) {
             // czh: TODO. try compile in batchAndUpdatePreAndSort->_renderUpdatePre
-            // elements[i].compileShader1(context)
+            // TODO
+            elements[i].compileShader1(context);
             elements[i]._render(this._context);
         }
 


### PR DESCRIPTION
enderfeature的pipelinemode在调用compileShader方法时，因为pipelinemode的设置导致，shader没有编译或没有给shaderInstance赋值，从而引起renderfeature没有绘制